### PR TITLE
Add Bash requirement for installation on Windows

### DIFF
--- a/doc/setup/index.md
+++ b/doc/setup/index.md
@@ -74,7 +74,9 @@ Besides `mmt.jar`, this directory contains executable scripts (for Windows and U
 
 In the previous, you obtained the file `mmt.jar` (by downloading or building).
 
-To start setup open a shell and run `java -jar mmt.jar`.
+To start setup open a shell and run `java -jar mmt.jar`.<br>
+On Windows, be sure to have `sh` on your current PATH, inside which `git` is available. For instance, you could directly issue the `java -jar mmt.jar` command from within Git Bash from an existing [Git for Windows](https://gitforwindows.org/) installation.
+
 This triggers the setup dialog which does the following:
 
 1. asks for a directory into which MMT should be installed


### PR DESCRIPTION
On Windows the setup will start 'sh --login -c "git clone https://....git", see
https://github.com/UniFormal/MMT/blob/227acab650e7c2409500da612c677fe815afef31/src/mmt-api/src/main/info/kwarc/mmt/api/archives/lmh/Git.scala#L38

If "sh" is not on the PATH, this results in the following error:

```
cloning or downloading content repositories (I'll try to use git; if that fails, I download a zip file)
user: 'lmh clone MMT/examples'
running command: sh --login -c "git clone https://gl.mathhub.info/MMT/examples.git MMT/examples"
in directory: D:\...\MMT\content\MathHub
  error: (lmh) git clone https://gl.mathhub.info/MMT/examples.git failed
```

**Related:**

https://github.com/UniFormal/MMT/issues/66#issuecomment-150260916 says that generally in order for MMT to work on Windows:
> At least "sh" and "git" must be installed.